### PR TITLE
added fixScript.

### DIFF
--- a/contact-details.txt
+++ b/contact-details.txt
@@ -1,2 +1,2 @@
-name: first last
-email: name@email.com
+name: Gil Levin
+email: gil.levin@dell.com

--- a/vagrant/fixScripts/exercise1-fix.sh
+++ b/vagrant/fixScripts/exercise1-fix.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
 #add fix to exercise1 here
+sudo route del 208.86.224.90
+# I've seen a strange route with "route -n" and deleting it fixed the issue.

--- a/vagrant/fixScripts/exercise2-fix.sh
+++ b/vagrant/fixScripts/exercise2-fix.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 #add fix to exercise2 here
+sudo sed -i '/127.0.0.1 www.ascii-art.de/ d' /etc/hosts

--- a/vagrant/fixScripts/exercise3-fix.sh
+++ b/vagrant/fixScripts/exercise3-fix.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
 #add fix to exercise3 here
+sudo sed -i 's/deny from all/Allow from all/' /etc/apache2/sites-enabled/000-default
+sudo service apache2 restart

--- a/vagrant/fixScripts/exercise4-fix_server1.sh
+++ b/vagrant/fixScripts/exercise4-fix_server1.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 #add fix to exercise4-server1 here
+sudo sed -i -e '$a\192.168.100.11 server2' /etc/hosts

--- a/vagrant/fixScripts/exercise4-fix_server2.sh
+++ b/vagrant/fixScripts/exercise4-fix_server2.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 #add fix to exercise4-server2 here
+sudo sh -c "echo 192.168.100.10 server1 >> /etc/hosts"

--- a/vagrant/fixScripts/exercise5-fix_server1.sh
+++ b/vagrant/fixScripts/exercise5-fix_server1.sh
@@ -4,3 +4,6 @@ ssh-keygen -f ~/.ssh/id_rsa -P ""
 ssh-copy-id server2
 #could have installed expect and wait for the 
 #password prompt to populate it with the users pass
+
+
+##NOTE: ssh-copy-id will fail the "vagrant up" command since server2 isn't up yet.

--- a/vagrant/fixScripts/exercise5-fix_server1.sh
+++ b/vagrant/fixScripts/exercise5-fix_server1.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
 #add fix to exercise5-server1 here
+ssh-keygen -f ~/.ssh/id_rsa -P ""
+ssh-copy-id server2
+#could have installed expect and wait for the 
+#password prompt to populate it with the users pass

--- a/vagrant/fixScripts/exercise5-fix_server2.sh
+++ b/vagrant/fixScripts/exercise5-fix_server2.sh
@@ -4,3 +4,6 @@ ssh-keygen -f ~/.ssh/id_rsa -P ""
 ssh-copy-id server1
 #could have installed expect and wait for the 
 #password prompt to populate it with the users pass
+
+
+##NOTE: ssh-copy-id will fail the "vagrant up" command since server1 isn't up yet.

--- a/vagrant/fixScripts/exercise5-fix_server2.sh
+++ b/vagrant/fixScripts/exercise5-fix_server2.sh
@@ -1,2 +1,6 @@
 #!/bin/bash
 #add fix to exercise5-server2 here
+ssh-keygen -f ~/.ssh/id_rsa -P ""
+ssh-copy-id server1
+#could have installed expect and wait for the 
+#password prompt to populate it with the users pass

--- a/vagrant/fixScripts/exercise6-fix.sh
+++ b/vagrant/fixScripts/exercise6-fix.sh
@@ -1,2 +1,26 @@
 #!/bin/bash
 #add fix to exercise6-fix here
+if [ $# -lt 2 ]; then
+    echo "At least 2 args are required"
+    exit 1
+else
+	user=$USER
+    hs=$HOSTNAME
+	copy_location=${@: -1}
+	total_copy_size=0
+    if [ $hs == server1 ]; then
+		remote_host=server2
+	else
+        remote_host=server1
+    fi
+	echo $copy_location
+	array=( "$@" )
+	unset "array[${#array[@]}-1]"    # Removes last element
+	for i in "${array[@]}"; do
+		scp $i $user@$remote_host:$copy_location
+		files_size=$(wc -c "$i" | awk '{print $1}')
+		let "total_copy_size += $files_size"
+	done
+	echo $total_copy_size
+fi
+


### PR DESCRIPTION
- Using vagrant the VM's won't be provishioned parallely, so coping the ssh-key will fail since server2 is down.
- could also avoid the prompt in "ssh-copy-id" if installed "expect" and wainted for relavnt prompt.